### PR TITLE
WebM support

### DIFF
--- a/BeatSaberTheater/PluginConfig.cs
+++ b/BeatSaberTheater/PluginConfig.cs
@@ -19,5 +19,6 @@ internal class PluginConfig
     public virtual int BloomIntensity { get; set; } = 100;
     public virtual float CornerRoundness { get; set; }
     public virtual VideoQuality.Mode QualityMode { get; set; } = VideoQuality.Mode.Q720P;
+    public virtual VideoFormats.Format Format { get; set; } = VideoFormats.Format.Mp4;
     public virtual bool ForceDisableEnvironmentOverrides { get; set; } = false;
 }

--- a/BeatSaberTheater/Services/DownloadService.cs
+++ b/BeatSaberTheater/Services/DownloadService.cs
@@ -271,8 +271,9 @@ public class DownloadService : YoutubeDLServiceBase
 
         if (format == VideoFormats.Format.Webm)
         {
+            var threadsToUse = Math.Max(1, Math.Round(System.Environment.ProcessorCount / 2f));
             downloadProcessArguments +=
-                $" --ppa \"ffmpeg:-c:v libvpx -crf 10 -b:v 4M -c:a libvorbis -quality good -threads 8 -cpu-used 5 '{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm'\"";
+                $" --ppa \"ffmpeg:-c:v libvpx -crf 10 -b:v 4M -c:a libvorbis -quality good -threads {threadsToUse} -cpu-used 5 '{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm'\"";
             video.videoFile = Path.GetFileNameWithoutExtension(video.videoFile) + ".webm";
         }
         else

--- a/BeatSaberTheater/Services/DownloadService.cs
+++ b/BeatSaberTheater/Services/DownloadService.cs
@@ -272,7 +272,6 @@ public class DownloadService : YoutubeDLServiceBase
 
         if (format == VideoFormats.Format.Webm)
         {
-            var threadsToUse = Math.Max(1, Math.Round(System.Environment.ProcessorCount / 2f));
             downloadProcessArguments += $" --ppa \"ffmpeg:-c:v libvpx -crf 10 -b:v 4M -quality realtime -cpu-used 8 -c:a libvorbis '{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm'\"";
             video.videoFile = Path.GetFileNameWithoutExtension(video.videoFile) + ".webm";
         }

--- a/BeatSaberTheater/Services/DownloadService.cs
+++ b/BeatSaberTheater/Services/DownloadService.cs
@@ -285,7 +285,7 @@ public class DownloadService : YoutubeDLServiceBase
         var downloadProcessArguments = videoUrl +
                                        videoFormat +
                                        " --no-cache-dir" + // Don't use temp storage
-                                       $" -o \"{outputPath}.mp4\"" +
+                                       $" -o \"{outputPath}\"" +
                                        " --no-playlist" + // Don't download playlists, only the first video
                                        " --no-part" + // Don't store download in parts, write directly to file
                                        " --no-mtime" + //Video last modified will be when it was downloaded, not when it was uploaded to youtube

--- a/BeatSaberTheater/Services/DownloadService.cs
+++ b/BeatSaberTheater/Services/DownloadService.cs
@@ -293,7 +293,7 @@ public class DownloadService : YoutubeDLServiceBase
 
         if (format == VideoFormats.Format.Webm)
         {
-            downloadProcessArguments += $" --exec \"{Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe")} -i %(filepath,_filename|)q -progress pipe:1 -c:v libvpx -crf 10 -b:v 4M -quality realtime -cpu-used 8 -c:a libvorbis \"\"{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm\"\"\"";
+            downloadProcessArguments += $" --exec \"{Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe")} -i %(filepath,_filename|)q -progress pipe:1 -c:v libvpx -crf 10 -b:v 4M -quality realtime -cpu-used 8 -c:a libvorbis \\\"{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm\\\"\"";
             video.videoFile = Path.GetFileNameWithoutExtension(video.videoFile) + ".webm";
         }
         else

--- a/BeatSaberTheater/Services/DownloadService.cs
+++ b/BeatSaberTheater/Services/DownloadService.cs
@@ -273,8 +273,7 @@ public class DownloadService : YoutubeDLServiceBase
         if (format == VideoFormats.Format.Webm)
         {
             var threadsToUse = Math.Max(1, Math.Round(System.Environment.ProcessorCount / 2f));
-            downloadProcessArguments +=
-                $" --ppa \"ffmpeg:-c:v libvpx -crf 10 -b:v 4M -c:a libvorbis -quality good -threads {threadsToUse} -cpu-used 5 '{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm'\"";
+            downloadProcessArguments += $" --ppa \"ffmpeg:-c:v libvpx -crf 10 -b:v 4M -quality realtime -cpu-used 8 -c:a libvorbis '{Path.GetFileNameWithoutExtension(video.VideoPath)}.webm'\"";
             video.videoFile = Path.GetFileNameWithoutExtension(video.videoFile) + ".webm";
         }
         else

--- a/BeatSaberTheater/Settings/TheaterSettingsViewController.cs
+++ b/BeatSaberTheater/Settings/TheaterSettingsViewController.cs
@@ -17,6 +17,7 @@ internal class TheaterSettingsViewController
 
     private const float FADE_DURATION = 0.2f;
     [UIValue("modes")] [UsedImplicitly] private List<object> _qualityModes = VideoQuality.GetModeList();
+    [UIValue("formats")] [UsedImplicitly] private List<object> _videoFormats = VideoFormats.GetFormatList();
 
     [UIValue("show-video")]
     public bool PluginEnabled
@@ -113,6 +114,13 @@ internal class TheaterSettingsViewController
     {
         get => VideoQuality.ToName(_config.QualityMode);
         set => _config.QualityMode = VideoQuality.FromName(value);
+    }
+    
+    [UIValue("format")]
+    public string Format
+    {
+        get => VideoFormats.ToName(_config.Format);
+        set => _config.Format = VideoFormats.FromName(value);
     }
 
     private void SetSettingsTexture()

--- a/BeatSaberTheater/Settings/VideoFormats.cs
+++ b/BeatSaberTheater/Settings/VideoFormats.cs
@@ -1,0 +1,33 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+
+namespace BeatSaberTheater.Settings;
+
+public static class VideoFormats
+{
+	public enum Format
+	{
+		Mp4 = 0,
+		Webm = 1,
+	}
+	
+	public static string ToName(Format format)
+	{
+		return Enum.GetName(typeof(Format), format);
+	}
+
+	public static List<object> GetFormatList()
+	{
+		var enumArray = Enum.GetValues(typeof(Format));
+		var enumArrayFormatted = new object[enumArray.Length];
+		for (var i = 0; i < enumArray.Length; i++) enumArrayFormatted[i] = ToName((Format)enumArray.GetValue(i));
+		return enumArrayFormatted.ToList();
+	} 
+	
+	public static Format FromName(string mode)
+	{
+		return Enum.Parse<Format>(mode);
+	}
+}

--- a/BeatSaberTheater/Settings/Views/settings.bsml
+++ b/BeatSaberTheater/Settings/Views/settings.bsml
@@ -10,6 +10,8 @@
                           hover-hint='Enable or disable video playback and other features&#xD;&#xA;&#xD;&#xA;Recommended: On'></bool-setting>
             <dropdown-list-setting apply-on-change="true" text='Download Quality' value='quality'
                                    options='modes'></dropdown-list-setting>
+            <dropdown-list-setting apply-on-change="true" text='Format' value='format'
+                                   options='formats'></dropdown-list-setting>
             <bool-setting apply-on-change="true" text='Force "Big Mirror" Environment' value='override-environment'
                           hover-hint='Force the use of the Big Mirror environment for songs with videos.&#xD;&#xA;&#xD;&#xA;Recommended: On'></bool-setting>
             <bool-setting apply-on-change="true" text='Disable CustomPlatforms' value='disable-custom-platforms'

--- a/BeatSaberTheater/Video/Config/VideoConfig.cs
+++ b/BeatSaberTheater/Video/Config/VideoConfig.cs
@@ -46,6 +46,7 @@ public class VideoConfig
     public Vignette? vignette;
 
     [JsonIgnore] [NonSerialized] public float DownloadProgress;
+    [JsonIgnore] [NonSerialized] public float? ConvertingProgress;
     [JsonIgnore] [NonSerialized] public DownloadState DownloadState;
     [JsonIgnore] [NonSerialized] public string? ErrorMessage;
     [JsonIgnore] [NonSerialized] public string? LevelDir;

--- a/BeatSaberTheater/Video/Config/VideoConfig.cs
+++ b/BeatSaberTheater/Video/Config/VideoConfig.cs
@@ -3,6 +3,7 @@ using System.IO;
 using System.Linq;
 using BeatSaberTheater.Download;
 using BeatSaberTheater.Models;
+using BeatSaberTheater.Settings;
 using BeatSaberTheater.Util;
 using Newtonsoft.Json;
 using SongCore.Data;
@@ -154,7 +155,12 @@ public class VideoConfig
     {
         var fileName = videoFile ?? TheaterFileHelpers.ReplaceIllegalFilesystemChars(title ?? videoID ?? "video");
         fileName = TheaterFileHelpers.ShortenFilename(levelPath, fileName);
-        if (!fileName.EndsWith(".mp4")) fileName += ".mp4";
+
+        if (!Path.HasExtension(fileName))
+        {
+            fileName += ".mp4";
+        }
+        
         return fileName;
     }
 }

--- a/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
+++ b/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
@@ -399,7 +399,10 @@ public class VideoMenuUI : IInitializable, IDisposable
                 break;
             case DownloadState.Converting:
                 _levelDetailMenu.SetActive(true);
-                _levelDetailMenu.SetText($"Converting...",
+                var convertingText = videoConfig.ConvertingProgress.HasValue
+                    ? $"Converting ({videoConfig.ConvertingProgress:##}%)"
+                    : "Converting...";
+                _levelDetailMenu.SetText(convertingText,
                     "Cancel", Color.yellow, Color.red);
                 break;
             case DownloadState.NotDownloaded:
@@ -455,7 +458,10 @@ public class VideoMenuUI : IInitializable, IDisposable
                 _previewButton.interactable = false;
                 break;
             case DownloadState.Converting:
-                _videoStatusText.text = $"Converting...";
+                var convertingText = videoConfig.ConvertingProgress.HasValue
+                    ? $"Converting ({videoConfig.ConvertingProgress:##}%)"
+                    : "Converting...";
+                _videoStatusText.text = convertingText;
                 _videoStatusText.color = Color.yellow;
                 _previewButton.interactable = false;
                 break;

--- a/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
+++ b/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
@@ -399,10 +399,7 @@ public class VideoMenuUI : IInitializable, IDisposable
                 break;
             case DownloadState.Converting:
                 _levelDetailMenu.SetActive(true);
-                var convertingText = videoConfig.ConvertingProgress.HasValue
-                    ? $"Converting ({videoConfig.ConvertingProgress:##}%)"
-                    : "Converting...";
-                _levelDetailMenu.SetText(convertingText,
+                _levelDetailMenu.SetText(GetConversionProgressDisplayString(videoConfig),
                     "Cancel", Color.yellow, Color.red);
                 break;
             case DownloadState.NotDownloaded:
@@ -458,9 +455,7 @@ public class VideoMenuUI : IInitializable, IDisposable
                 _previewButton.interactable = false;
                 break;
             case DownloadState.Converting:
-                var convertingText = videoConfig.ConvertingProgress.HasValue
-                    ? $"Converting ({videoConfig.ConvertingProgress:##}%)"
-                    : "Converting...";
+                var convertingText = GetConversionProgressDisplayString(videoConfig);
                 _videoStatusText.text = convertingText;
                 _videoStatusText.color = Color.yellow;
                 _previewButton.interactable = false;
@@ -953,6 +948,15 @@ public class VideoMenuUI : IInitializable, IDisposable
     private void IncreaseOffsetLow()
     {
         ApplyOffset(20);
+    }
+
+    private string GetConversionProgressDisplayString(VideoConfig config)
+    {
+        var convertingText = config.ConvertingProgress.HasValue
+            ? $"Converting ({config.ConvertingProgress:##}%)"
+            : "Converting...";
+
+        return convertingText;
     }
 }
 

--- a/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
+++ b/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
@@ -735,7 +735,7 @@ public class VideoMenuUI : IInitializable, IDisposable
             case DownloadState.Cancelled:
                 _currentVideo.DownloadProgress = 0;
                 _searchService.StopSearch();
-                _downloadService.StartDownload(_currentVideo, _config.QualityMode);
+                _downloadService.StartDownload(_currentVideo, _config.QualityMode, _config.Format);
                 _currentVideo.NeedsToSave = true;
                 _videoLoader.AddConfigToCache(_currentVideo, _currentLevel!);
                 break;
@@ -894,7 +894,7 @@ public class VideoMenuUI : IInitializable, IDisposable
                 { NeedsToSave = true };
         _videoLoader.AddConfigToCache(config, _currentLevel);
         _searchService.StopSearch();
-        _downloadService.StartDownload(config, _config.QualityMode);
+        _downloadService.StartDownload(config, _config.QualityMode, _config.Format);
         _currentVideo = config;
         SetupVideoDetails();
     }


### PR DESCRIPTION
Implements support for storing and playing back videos in Webm/VP8 format as an alternative for the default mp4 format. While using VP8 is more processor intensive while downloading/transcoding, and takes more space on the disk, the format has better cross-platform support and allows BeatSaberTheater to function on Linux.

This PR resolves issue: https://github.com/neboman11/BeatSaberTheater/issues/10

The video format can be toggled in the options menu, MP4 is the default value

<img width="3399" height="2039" alt="image" src="https://github.com/user-attachments/assets/96983891-51d9-47a2-bd17-61c6b9637e3f" />

<img width="3399" height="2039" alt="Screenshot_20250927_214842" src="https://github.com/user-attachments/assets/b6841e18-149f-4a57-af5e-89cdbe1b0eff" />

After enabling, webm videos will be generated alongside newly downloaded videos

<img width="1220" height="740" alt="Screenshot_20250927_215044" src="https://github.com/user-attachments/assets/2d58bdae-b3bc-4afb-b428-56104229dbcb" />

