### PR TITLE
fix: Prevent BeatSaberTheater from breaking in multiplayer

### DIFF
--- a/BeatSaberTheater/Environment/EnvironmentManipulator.cs
+++ b/BeatSaberTheater/Environment/EnvironmentManipulator.cs
@@ -106,6 +106,7 @@ public class EnvironmentManipulator : IInitializable
     private void SceneChanged(UnityEngine.SceneManagement.Scene arg0, UnityEngine.SceneManagement.Scene arg1)
     {
         _loggingService.Debug($"Scene changed from {arg0.name} to {arg1.name}");
+        Object.DontDestroyOnLoad(_playbackManager);
         var sceneName = arg1.name;
         switch (sceneName)
         {

--- a/BeatSaberTheater/Environment/EnvironmentManipulator.cs
+++ b/BeatSaberTheater/Environment/EnvironmentManipulator.cs
@@ -106,7 +106,11 @@ public class EnvironmentManipulator : IInitializable
     private void SceneChanged(UnityEngine.SceneManagement.Scene arg0, UnityEngine.SceneManagement.Scene arg1)
     {
         _loggingService.Debug($"Scene changed from {arg0.name} to {arg1.name}");
+        
+        // Prevent _playbackManager from being unloaded on scene change. Should fix BeatSaberTheater from breaking
+        // after playing a multiplayer map
         Object.DontDestroyOnLoad(_playbackManager);
+
         var sceneName = arg1.name;
         switch (sceneName)
         {


### PR DESCRIPTION
Before this commit, the PlaybackManager instance would get lost/destroyed after scene changing from a multiplayer scene to any other. This would break BeatSaberTheater and required a game restart.

## Expected behavior

Theater always works, regardless of gameplay mode.

## Actual behavior

Entering a multiplayer match breaks the plugin by permanently removing the playback manager

## Before patch

https://github.com/user-attachments/assets/07b2fc0d-eeb0-45b2-959c-cb578297c541

Note: After playing the MP map once, videos no longer play in single player mode. Videos will also play in consecutive MP maps.

## After patch

https://github.com/user-attachments/assets/79e20680-b724-4c07-8d03-e447a136eb48

Note: After playing the MP map once, videos remain playable in single player mode.
