### PR TITLE
Use BSMT's `OutputCopy` Instead of Copying the Playlist File Ourselves

### DIFF
--- a/BeatSaberTheater/BeatSaberTheater.csproj
+++ b/BeatSaberTheater/BeatSaberTheater.csproj
@@ -225,11 +225,4 @@
             <Private>false</Private>
         </Reference>
     </ItemGroup>
-
-    <Target Name="FlattenForRelease" AfterTargets="Build">
-        <Copy SourceFiles="Resources\cinema.bplist"
-              DestinationFolder="$(OutputPath)/Artifact/Playlists"
-              SkipUnchangedFiles="true"/>
-    </Target>
-
 </Project>

--- a/BeatSaberTheater/Directory.Build.props
+++ b/BeatSaberTheater/Directory.Build.props
@@ -38,4 +38,10 @@
         <DisableZipRelease>true</DisableZipRelease>
     </PropertyGroup>
 
+    <ItemGroup>
+        <OutputCopy Include="$(OutputPath)\$(TargetFileName)" OutputPath="Plugins\$(TargetFileName)"/>
+        <OutputCopy Include="$(OutputPath)\$(TargetName).pdb" OutputPath="Plugins\$(TargetName).pdb"/>
+        <OutputCopy Include="$(OutputPath)\Resources\cinema.bplist" OutputPath="Playlists\cinema.bplist"/>
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
BSMT supports customizing the output files being copied into destination folders. By using this feature, we can tell BSMT to copy the playlist file into the correct location. As a result, the file will be included in the artifact, the output zip and also the game directory.