### PR TITLE
Make BetterSongList an optional dependency

### DIFF
--- a/BeatSaberTheater/BeatSaberTheater.csproj
+++ b/BeatSaberTheater/BeatSaberTheater.csproj
@@ -81,10 +81,6 @@
             <HintPath>$(BeatSaberDir)\Libs\BeatSaberPlaylistsLib.dll</HintPath>
             <Private>false</Private>
         </Reference>
-        <Reference Include="BetterSongList">
-            <HintPath>$(BeatSaberDir)\Plugins\BetterSongList.dll</HintPath>
-            <Private>false</Private>
-        </Reference>
         <Reference Include="BGLib.AppFlow">
             <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
             <Private>false</Private>

--- a/BeatSaberTheater/Directory.Build.props
+++ b/BeatSaberTheater/Directory.Build.props
@@ -25,7 +25,6 @@
         <DependsOn Include="BeatSaberPlaylistsLib" Version="^1.7.0"/>
         <!--        <DependsOn Include="FFmpeg" Version="^4.3.0"/>-->
         <DependsOn Include="BeatSaberMarkupLanguage" Version="^1.12.0"/>
-        <DependsOn Include="BetterSongList" Version="^0.4.0"/>
     </ItemGroup>
 
     <PropertyGroup>

--- a/BeatSaberTheater/Plugin.cs
+++ b/BeatSaberTheater/Plugin.cs
@@ -104,11 +104,12 @@ internal class Plugin
     {
         if (!InstalledMods.BetterSongList || _filterAdded) return;
 
-        _filterAdded = HasVideoFilter.Register();
+        var videoFilter = VideoFilterRegister.CreateVideoFilterIfBetterSongListPresent();
+        _filterAdded = videoFilter();
 
         if (_filterAdded)
-            _log.Debug($"Registered {nameof(HasVideoFilter)}");
+            _log.Info($"Registered Video Filter");
         else
-            _log.Error($"Failed to register {nameof(HasVideoFilter)}");
+            _log.Warn($"Failed to register Video Filter");
     }
 }

--- a/BeatSaberTheater/Plugin.cs
+++ b/BeatSaberTheater/Plugin.cs
@@ -104,7 +104,7 @@ internal class Plugin
     {
         if (!InstalledMods.BetterSongList || _filterAdded) return;
 
-        _filterAdded = BetterSongList.FilterMethods.Register(new HasVideoFilter());
+        _filterAdded = HasVideoFilter.Register();
 
         if (_filterAdded)
             _log.Debug($"Registered {nameof(HasVideoFilter)}");

--- a/BeatSaberTheater/PluginConfig.cs
+++ b/BeatSaberTheater/PluginConfig.cs
@@ -6,7 +6,7 @@ using IPA.Config.Stores;
 
 namespace BeatSaberTheater;
 
-internal class PluginConfig
+public class PluginConfig
 {
     public virtual bool PluginEnabled { get; set; } = true;
     public virtual bool OverrideEnvironment { get; set; } = true;

--- a/BeatSaberTheater/Settings/HasVideoFilter.cs
+++ b/BeatSaberTheater/Settings/HasVideoFilter.cs
@@ -8,6 +8,13 @@ namespace BeatSaberTheater.Settings;
 
 public class HasVideoFilter : IFilter, ITransformerPlugin
 {
+    // Must not be called unless BetterSongList is confirmed installed (see InstalledMods.BetterSongList).
+    // Kept isolated from Plugin.cs so the JIT doesn't have to resolve BetterSongList types when it's absent.
+    public static bool Register()
+    {
+        return BetterSongList.FilterMethods.Register(new HasVideoFilter());
+    }
+
     public bool isReady => true;
     public string name => "Theater";
     public bool visible { get; } = true; //Plugin.Enabled && SettingsStore.Instance.PluginEnabled;

--- a/BeatSaberTheater/Settings/HasVideoFilter.cs
+++ b/BeatSaberTheater/Settings/HasVideoFilter.cs
@@ -1,36 +1,126 @@
-﻿using System.Threading;
+using System;
+using System.Linq;
+using System.Reflection;
+using System.Reflection.Emit;
+using System.Threading;
 using System.Threading.Tasks;
 using BeatSaberTheater.Video;
-using BetterSongList.FilterModels;
-using BetterSongList.Interfaces;
 
 namespace BeatSaberTheater.Settings;
 
-public class HasVideoFilter : IFilter, ITransformerPlugin
+public class VideoFilterRegister
 {
-    // Must not be called unless BetterSongList is confirmed installed (see InstalledMods.BetterSongList).
-    // Kept isolated from Plugin.cs so the JIT doesn't have to resolve BetterSongList types when it's absent.
-    public static bool Register()
+    public static Func<bool> CreateVideoFilterIfBetterSongListPresent()
     {
-        return BetterSongList.FilterMethods.Register(new HasVideoFilter());
-    }
+        try
+        {
+            Assembly? betterSongListAssembly = AppDomain.CurrentDomain.GetAssemblies()
+                .FirstOrDefault(assembly => assembly.GetName().Name == "BetterSongList");
+            if (betterSongListAssembly == null)
+            {
+                throw new InvalidOperationException("BetterSongList assembly is not loaded in the AppDomain");
+            }
 
-    public bool isReady => true;
-    public string name => "Theater";
-    public bool visible { get; } = true; //Plugin.Enabled && SettingsStore.Instance.PluginEnabled;
+            Type iFilterType = betterSongListAssembly.GetType("BetterSongList.FilterModels.IFilter");
+            Type iTransformerPluginType = betterSongListAssembly.GetType("BetterSongList.Interfaces.ITransformerPlugin");
 
-    public bool GetValueFor(BeatmapLevel level)
-    {
-        return VideoLoader.LevelHasVideo(level);
-    }
+            AssemblyName assemblyName = new AssemblyName("DynamicAssembly");
+            AssemblyBuilder assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+            ModuleBuilder moduleBuilder = assemblyBuilder.DefineDynamicModule("DynamicModule");
 
-    public Task Prepare(CancellationToken cancelToken)
-    {
-        return Task.CompletedTask;
-    }
+            TypeBuilder typeBuilder = moduleBuilder.DefineType("BeatSaberTheater.Settings.HasVideoFilter",
+                TypeAttributes.Public | TypeAttributes.Class);
 
-    public void ContextSwitch(SelectLevelCategoryViewController.LevelCategory levelCategory, BeatmapLevelPack? playlist)
-    {
-        //Not needed
+            typeBuilder.AddInterfaceImplementation(iFilterType);
+            typeBuilder.AddInterfaceImplementation(iTransformerPluginType);
+
+            PropertyBuilder isReadyProperty = typeBuilder.DefineProperty("isReady", PropertyAttributes.None, typeof(bool), null);
+            MethodBuilder isReadyGetMethod = typeBuilder.DefineMethod("get_isReady",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName,
+                typeof(bool), Type.EmptyTypes);
+            ILGenerator isReadyIL = isReadyGetMethod.GetILGenerator();
+            isReadyIL.Emit(OpCodes.Ldc_I4_1);
+            isReadyIL.Emit(OpCodes.Ret);
+            isReadyProperty.SetGetMethod(isReadyGetMethod);
+
+            PropertyBuilder nameProperty = typeBuilder.DefineProperty("name", PropertyAttributes.None, typeof(string), null);
+            MethodBuilder nameGetMethod = typeBuilder.DefineMethod("get_name",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName,
+                typeof(string), Type.EmptyTypes);
+            ILGenerator nameIL = nameGetMethod.GetILGenerator();
+            nameIL.Emit(OpCodes.Ldstr, "Theater");
+            nameIL.Emit(OpCodes.Ret);
+            nameProperty.SetGetMethod(nameGetMethod);
+
+            PropertyBuilder visibleProperty = typeBuilder.DefineProperty("visible", PropertyAttributes.None, typeof(bool), null);
+            MethodBuilder visibleGetMethod = typeBuilder.DefineMethod("get_visible",
+                MethodAttributes.Public | MethodAttributes.Virtual | MethodAttributes.SpecialName,
+                typeof(bool), Type.EmptyTypes);
+
+            ILGenerator visibleIL = visibleGetMethod.GetILGenerator();
+            visibleIL.Emit(OpCodes.Ldc_I4_1);
+            visibleIL.Emit(OpCodes.Ret);
+            visibleProperty.SetGetMethod(visibleGetMethod);
+
+            MethodBuilder getValueForMethod = typeBuilder.DefineMethod("GetValueFor",
+                MethodAttributes.Public | MethodAttributes.Virtual,
+                typeof(bool),
+                [typeof(BeatmapLevel)]);
+
+            ILGenerator getValueForIL = getValueForMethod.GetILGenerator();
+            getValueForIL.Emit(OpCodes.Ldarg_1);
+            getValueForIL.EmitCall(OpCodes.Call, typeof(VideoLoader).GetMethod("LevelHasVideo", BindingFlags.Public | BindingFlags.Static), null);
+            getValueForIL.Emit(OpCodes.Ret);
+
+            MethodBuilder prepareMethod = typeBuilder.DefineMethod("Prepare",
+                MethodAttributes.Public | MethodAttributes.Virtual,
+                typeof(Task),
+                [typeof(CancellationToken)]);
+
+            ILGenerator prepareMethodIL = prepareMethod.GetILGenerator();
+            prepareMethodIL.EmitCall(OpCodes.Call, typeof(Task).GetProperty("CompletedTask", BindingFlags.Public | BindingFlags.Static).GetGetMethod(), null);
+            prepareMethodIL.Emit(OpCodes.Ret);
+
+            MethodBuilder contextSwitchMethod = typeBuilder.DefineMethod("ContextSwitch",
+                MethodAttributes.Public | MethodAttributes.Virtual,
+                typeof(void),
+                [
+                    typeof(SelectLevelCategoryViewController.LevelCategory),
+                    typeof(BeatmapLevelPack),
+                ]);
+
+            var contextSwitchMethodIL = contextSwitchMethod.GetILGenerator();
+            contextSwitchMethodIL.Emit(OpCodes.Ret);
+
+            var videoFilterType = typeBuilder.CreateType();
+            var instance = Activator.CreateInstance(videoFilterType);
+
+            Type filterMethodsType = betterSongListAssembly.GetType("BetterSongList.FilterMethods");
+            MethodInfo registerMethod = filterMethodsType
+                .GetMethod("Register")
+                .MakeGenericMethod(videoFilterType);
+
+            bool Register()
+            {
+                var returnValue = registerMethod?.Invoke(null, [instance]);
+                if (returnValue != null)
+                {
+                    return (bool)returnValue;
+                }
+                else
+                {
+                    return false;
+                }
+            }
+
+            return Register;
+        }
+        catch (Exception e)
+        {
+            Plugin._log.Warn(e);
+            Plugin._log.Warn("Could not register Video Filter");
+
+            return () => false;
+        }
     }
 }

--- a/BeatSaberTheater/Video/VideoLoader.cs
+++ b/BeatSaberTheater/Video/VideoLoader.cs
@@ -23,7 +23,7 @@ using Zenject;
 
 namespace BeatSaberTheater.Video;
 
-internal class VideoLoader(
+public class VideoLoader(
     PluginConfig _config,
     TheaterCoroutineStarter _coroutineStarter,
     LoggingService _loggingService,

--- a/Readme.md
+++ b/Readme.md
@@ -20,6 +20,8 @@ This mod is not yet available on BeatMods and must be installed manually.
 This mod has several dependencies, ensure they are all installed before launching the game. These dependencies
 can be installed through your favorite mod manager (BSManager, ModAssistant, etc.).
 
+#### Required
+
 * BSIPA
 * SongCore
 * BS Utils
@@ -27,6 +29,9 @@ can be installed through your favorite mod manager (BSManager, ModAssistant, etc
 * BeatSaberPlaylistsLib
 * ffmpeg
 * BeatSaberMarkupLanguage
+
+#### Optional
+
 * BetterSongList
 
 ## Usage


### PR DESCRIPTION
## Summary
- Removed `BetterSongList` from `DependsOn` in `Directory.Build.props`, so it's no longer a hard manifest dependency — we already gate its use behind `InstalledMods.BetterSongList`.
- Isolated the `HasVideoFilter`/`BetterSongList.FilterMethods.Register` usage into a static `HasVideoFilter.Register()` method, mirroring the existing pattern used for the optional `BeatSaberPlaylistsLib` dependency (`PlaylistSongUtils`). The JIT resolves all type tokens referenced in a method body at compile time regardless of untaken branches, so without this the existing runtime guard alone wouldn't have prevented a `TypeLoadException` when BetterSongList is absent.

Fixes #39