### PR TITLE
Fix ffmpeg not found by yt-dlp during video download

### DIFF
--- a/BeatSaberTheater/Services/DownloadService.cs
+++ b/BeatSaberTheater/Services/DownloadService.cs
@@ -372,14 +372,15 @@ internal class DownloadService : YoutubeDLServiceBase
                                        " --no-part" + // Don't store download in parts, write directly to file
                                        " --no-mtime" + //Video last modified will be when it was downloaded, not when it was uploaded to youtube
                                        " --socket-timeout 10" + //Retry if no response in 10 seconds Note: Not if download takes more than 10 seconds but if the time between any 2 messages from the server is 10 seconds
-                                       $" --js-runtimes deno:\"{_ytDlpUpdateService.DenoDlpPath}\"";
+                                       $" --js-runtimes deno:\"{_ytDlpUpdateService.DenoDlpPath}\"" +
+                                       $" --ffmpeg-location \"{TheaterFileHelpers.TheaterLibsPath}\""; // Explicitly point yt-dlp to our ffmpeg so format merging doesn't rely on it being found automatically
 
         switch (format)
         {
             case VideoFormats.Format.Webm:
                 var webmFileName = Path.GetFileNameWithoutExtension(baseFileName) + ".webm";
                 var webmPath = Path.Combine(folder, webmFileName);
-                downloadProcessArguments += $" --exec \"{Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe")} -i %(filepath,_filename|)q -progress pipe:1 -c:v libvpx -crf 10 -b:v 4M -quality realtime -cpu-used 8 -c:a libvorbis \\\"{webmFileName}\\\"\"";
+                downloadProcessArguments += $" --exec \"{Path.Combine(TheaterFileHelpers.TheaterLibsPath, "ffmpeg.exe")} -i %(filepath,_filename|)q -progress pipe:1 -c:v libvpx -crf 10 -b:v 4M -quality realtime -cpu-used 8 -c:a libvorbis \\\"{webmFileName}\\\"\"";
                 video.DownloadedFormats[VideoFormats.Format.Webm] = webmPath;
                 break;
             case VideoFormats.Format.Mp4:

--- a/BeatSaberTheater/Services/YoutubeDLServiceBase.cs
+++ b/BeatSaberTheater/Services/YoutubeDLServiceBase.cs
@@ -10,7 +10,7 @@ namespace BeatSaberTheater.Services;
 
 internal abstract class YoutubeDLServiceBase : IInitializable
 {
-    private readonly string _ffmpegFilepath = Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe");
+    private readonly string _ffmpegFilepath = Path.Combine(TheaterFileHelpers.TheaterLibsPath, "ffmpeg.exe");
     protected readonly PluginConfig _config;
 
     private bool? _librariesAvailable;

--- a/BeatSaberTheater/Services/YtDlpUpdateService.cs
+++ b/BeatSaberTheater/Services/YtDlpUpdateService.cs
@@ -170,24 +170,29 @@ public class YtDlpUpdateService : IInitializable
             }
 
             _loggingService.Info("Downloaded latest yt-dlp.exe");
-
-            // Copy ffmpeg.exe to Theater directory if it doesn't exist
-            string theaterFfmpegPath = Path.Combine(TheaterFileHelpers.TheaterLibsPath, "ffmpeg.exe");
-            if (!File.Exists(theaterFfmpegPath))
-            {
-                string baseFfmpegPath = Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe");
-                if (File.Exists(baseFfmpegPath))
-                {
-                    File.Copy(baseFfmpegPath, theaterFfmpegPath);
-                    _loggingService.Info("Copied ffmpeg.exe to Theater directory");
-                }
-            }
         }
         catch (Exception ex)
         {
             _loggingService.Error($"Error downloading yt-dlp: {ex}");
             _config.PluginEnabled = false;
         }
+    }
+
+    private void EnsureFfmpegPresent()
+    {
+        var theaterFfmpegPath = Path.Combine(TheaterFileHelpers.TheaterLibsPath, "ffmpeg.exe");
+        if (File.Exists(theaterFfmpegPath)) return;
+
+        var baseFfmpegPath = Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe");
+        if (!File.Exists(baseFfmpegPath))
+        {
+            _loggingService.Warn("ffmpeg.exe was not found in the Theater library path or the base library path");
+            return;
+        }
+
+        if (!Directory.Exists(TheaterFileHelpers.TheaterLibsPath)) Directory.CreateDirectory(TheaterFileHelpers.TheaterLibsPath);
+        File.Copy(baseFfmpegPath, theaterFfmpegPath);
+        _loggingService.Info("Copied ffmpeg.exe to Theater directory");
     }
 
     public void Initialize()
@@ -200,6 +205,7 @@ public class YtDlpUpdateService : IInitializable
     {
         try
         {
+            EnsureFfmpegPresent();
             var tasks = new List<Task> { CheckAndDownloadDeno() };
             if (await CheckForUpdate())
             {

--- a/BeatSaberTheater/Services/YtDlpUpdateService.cs
+++ b/BeatSaberTheater/Services/YtDlpUpdateService.cs
@@ -4,6 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using BeatSaberTheater.Util;
 using IPA.Utilities;
@@ -178,10 +179,43 @@ public class YtDlpUpdateService : IInitializable
         }
     }
 
+    private bool IsFfmpegWorking(string ffmpegPath)
+    {
+        try
+        {
+            var process = new Process
+            {
+                StartInfo = new ProcessStartInfo
+                {
+                    FileName = ffmpegPath,
+                    Arguments = "-version",
+                    RedirectStandardOutput = true,
+                    UseShellExecute = false,
+                    CreateNoWindow = true
+                }
+            };
+            process.Start();
+            var output = process.StandardOutput.ReadToEnd();
+            process.WaitForExit();
+            return Regex.IsMatch(output, "ffmpeg version .*?Copyright", RegexOptions.Singleline);
+        }
+        catch (Exception ex)
+        {
+            _loggingService.Warn($"Failed to execute ffmpeg.exe at '{ffmpegPath}': {ex.Message}");
+            return false;
+        }
+    }
+
     private void EnsureFfmpegPresent()
     {
         var theaterFfmpegPath = Path.Combine(TheaterFileHelpers.TheaterLibsPath, "ffmpeg.exe");
-        if (File.Exists(theaterFfmpegPath)) return;
+        if (File.Exists(theaterFfmpegPath))
+        {
+            if (IsFfmpegWorking(theaterFfmpegPath)) return;
+
+            _loggingService.Warn("ffmpeg.exe in the Theater library path is present but not working. Removing it and attempting to restore it from the base library path");
+            File.Delete(theaterFfmpegPath);
+        }
 
         var baseFfmpegPath = Path.Combine(UnityGame.LibraryPath, "ffmpeg.exe");
         if (!File.Exists(baseFfmpegPath))
@@ -191,7 +225,16 @@ public class YtDlpUpdateService : IInitializable
         }
 
         if (!Directory.Exists(TheaterFileHelpers.TheaterLibsPath)) Directory.CreateDirectory(TheaterFileHelpers.TheaterLibsPath);
-        File.Copy(baseFfmpegPath, theaterFfmpegPath);
+        File.Copy(baseFfmpegPath, theaterFfmpegPath, true);
+
+        if (!IsFfmpegWorking(theaterFfmpegPath))
+        {
+            _loggingService.Error("ffmpeg.exe was copied from the base library path but is not working. Disabling plugin");
+            File.Delete(theaterFfmpegPath);
+            _config.PluginEnabled = false;
+            return;
+        }
+
         _loggingService.Info("Copied ffmpeg.exe to Theater directory");
     }
 

--- a/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
+++ b/BeatSaberTheater/VideoMenu/VideoMenuUI.cs
@@ -16,7 +16,6 @@ using BeatSaberTheater.Util;
 using BeatSaberTheater.Video;
 using BeatSaberTheater.Video.Config;
 using HMUI;
-using IPA.Utilities;
 using JetBrains.Annotations;
 using SongCore.Data;
 using TMPro;
@@ -161,7 +160,7 @@ public class VideoMenuUI : IInitializable, IDisposable
 
         if (!_downloadService.LibrariesAvailable())
             _loggingService.Warn(
-                $"One or more of the libraries are missing. Downloading videos will not work. To fix this, reinstall Theater and make sure yt-dlp and ffmpeg are in the Libs folder of Beat Saber, which is located at {UnityGame.LibraryPath}.");
+                $"One or more of the libraries are missing. Downloading videos will not work. To fix this, reinstall Theater and make sure yt-dlp and ffmpeg are in the Theater Libs folder, which is located at {TheaterFileHelpers.TheaterLibsPath}.");
     }
 
     public void Dispose()


### PR DESCRIPTION
## Summary
- Fixes #42 — yt-dlp couldn't reliably find ffmpeg to merge separately downloaded video/audio streams, causing "ffmpeg is not installed" warnings and unmerged files.
- Root cause: several code paths still referenced the old BSManager `Libs/` ffmpeg location instead of the Theater-managed `Libs/Theater/ffmpeg.exe` that the plugin actually downloads to.
- Pass `--ffmpeg-location` explicitly to the yt-dlp command pointing at `TheaterFileHelpers.TheaterLibsPath` (this is the long-term fix identified in the issue discussion).
- Fixed the webm `--exec` ffmpeg invocation to use the correct Theater libs path.
- Fixed `YoutubeDLServiceBase.LibrariesAvailable()` to check for ffmpeg in `Libs/Theater` instead of `Libs/`, and updated the resulting user-facing warning message accordingly.
- Fixed `ffmpeg.exe` only being (re-)copied into `Libs/Theater` as a side effect of downloading a new yt-dlp.exe. If yt-dlp was already up to date but ffmpeg was removed from `Libs/Theater`, it never got restored. It's now checked and restored on every startup.