### PR TITLE
Add setting to render video screen in front of environment

### DIFF
--- a/BeatSaberTheater/PluginConfig.cs
+++ b/BeatSaberTheater/PluginConfig.cs
@@ -16,6 +16,7 @@ internal class PluginConfig
     public virtual bool TransparencyEnabled { get; set; } = true;
     public virtual bool ColorBlendingEnabled { get; set; } = true;
     public virtual bool CoverEnabled { get; set; }
+    public virtual bool RenderInFrontOfEnvironment { get; set; }
     public virtual int BloomIntensity { get; set; } = 100;
     public virtual float CornerRoundness { get; set; }
     public virtual VideoQuality.Mode QualityMode { get; set; } = VideoQuality.Mode.Q720P;

--- a/BeatSaberTheater/Screen/ScreenManager.cs
+++ b/BeatSaberTheater/Screen/ScreenManager.cs
@@ -42,7 +42,13 @@ public class ScreenManager : IInitializable
     private static int SrcAlpha => _srcAlpha ??= Shader.PropertyToID("_SrcAlpha");
     private static int? _destAlpha;
     private static int DestAlpha => _destAlpha ??= Shader.PropertyToID("_DestAlpha");
+    private static int? _zTest;
+    private static int ZTest => _zTest ??= Shader.PropertyToID("_ZTest");
     private const string BODY_SHADER_NAME = "Custom/OpaqueNeonLight";
+
+    // Only takes effect on shaders that expose _ZTest as a property (falls back to the shader's compiled default otherwise)
+    private const int IN_FRONT_RENDER_QUEUE = (int)UnityEngine.Rendering.RenderQueue.Overlay;
+    private const int DEFAULT_RENDER_QUEUE = -1;
 
     private readonly PluginConfig _config;
     private readonly ICurvedSurfaceFactory _curvedSurfaceFactory;
@@ -149,6 +155,29 @@ public class ScreenManager : IInitializable
         }
 
         bodyRenderer.material.color = new Color(0, 0, 0, 0);
+        ApplyRenderInFrontOfEnvironment(bodyRenderer.material);
+    }
+
+    public void SetRenderInFrontOfEnvironment(bool enabled)
+    {
+        foreach (var screenGroup in ScreenGroups)
+        {
+            ApplyRenderInFrontOfEnvironment(screenGroup.Screen.GetComponent<Renderer>().material);
+
+            var body = screenGroup.Screen.transform.Find("Body");
+            var bodyRenderer = body != null ? body.GetComponent<Renderer>() : null;
+            if (bodyRenderer != null) ApplyRenderInFrontOfEnvironment(bodyRenderer.material);
+        }
+    }
+
+    private void ApplyRenderInFrontOfEnvironment(Material material)
+    {
+        var enabled = _config.RenderInFrontOfEnvironment;
+        material.renderQueue = enabled ? IN_FRONT_RENDER_QUEUE : DEFAULT_RENDER_QUEUE;
+        material.SetInt(ZTest,
+            (int)(enabled
+                ? UnityEngine.Rendering.CompareFunction.Always
+                : UnityEngine.Rendering.CompareFunction.LessEqual));
     }
 
     public void SetScreensActive(bool active)
@@ -261,6 +290,8 @@ public class ScreenManager : IInitializable
 
             var colorCorrection = config?.colorCorrection;
             var vignette = config?.vignette;
+
+            ApplyRenderInFrontOfEnvironment(screenRenderer.material);
 
             screenRenderer.GetPropertyBlock(_materialPropertyBlock);
 

--- a/BeatSaberTheater/Screen/ScreenManager.cs
+++ b/BeatSaberTheater/Screen/ScreenManager.cs
@@ -48,7 +48,6 @@ public class ScreenManager : IInitializable
 
     // Only takes effect on shaders that expose _ZTest as a property (falls back to the shader's compiled default otherwise)
     private const int IN_FRONT_RENDER_QUEUE = (int)UnityEngine.Rendering.RenderQueue.Overlay;
-    private const int DEFAULT_RENDER_QUEUE = -1;
 
     private readonly PluginConfig _config;
     private readonly ICurvedSurfaceFactory _curvedSurfaceFactory;
@@ -172,12 +171,13 @@ public class ScreenManager : IInitializable
 
     private void ApplyRenderInFrontOfEnvironment(Material material)
     {
-        var enabled = _config.RenderInFrontOfEnvironment;
-        material.renderQueue = enabled ? IN_FRONT_RENDER_QUEUE : DEFAULT_RENDER_QUEUE;
-        material.SetInt(ZTest,
-            (int)(enabled
-                ? UnityEngine.Rendering.CompareFunction.Always
-                : UnityEngine.Rendering.CompareFunction.LessEqual));
+        // Leave the material untouched when disabled instead of resetting renderQueue/ZTest to
+        // hardcoded values - the shipped materials may rely on non-default values for correct
+        // compositing (e.g. bloom pre-pass ordering), which we can't know from this repo.
+        if (!_config.RenderInFrontOfEnvironment) return;
+
+        material.renderQueue = IN_FRONT_RENDER_QUEUE;
+        material.SetInt(ZTest, (int)UnityEngine.Rendering.CompareFunction.Always);
     }
 
     public void SetScreensActive(bool active)

--- a/BeatSaberTheater/Screen/ScreenManager.cs
+++ b/BeatSaberTheater/Screen/ScreenManager.cs
@@ -291,7 +291,10 @@ public class ScreenManager : IInitializable
             var colorCorrection = config?.colorCorrection;
             var vignette = config?.vignette;
 
-            ApplyRenderInFrontOfEnvironment(screenRenderer.material);
+            // Guard before touching .material at all - accessing it force-instantiates a unique
+            // material clone (unlike sharedMaterial), which we only want to pay for when the
+            // setting is actually enabled.
+            if (_config.RenderInFrontOfEnvironment) ApplyRenderInFrontOfEnvironment(screenRenderer.material);
 
             screenRenderer.GetPropertyBlock(_materialPropertyBlock);
 

--- a/BeatSaberTheater/Settings/TheaterSettingsViewController.cs
+++ b/BeatSaberTheater/Settings/TheaterSettingsViewController.cs
@@ -109,6 +109,13 @@ internal class TheaterSettingsViewController
         set => _config.CoverEnabled = value;
     }
 
+    [UIValue("render-in-front-of-environment")]
+    public bool RenderInFrontOfEnvironment
+    {
+        get => _config.RenderInFrontOfEnvironment;
+        set => _config.RenderInFrontOfEnvironment = value;
+    }
+
     [UIValue("quality")]
     public string QualityMode
     {

--- a/BeatSaberTheater/Settings/Views/settings.bsml
+++ b/BeatSaberTheater/Settings/Views/settings.bsml
@@ -43,6 +43,8 @@
             <slider-setting apply-on-change="true" integer-only="true" value="corner-roundness" text="Corner Roundness"
                             hover-hint="Adjust the roundness of the screen's corners to your preference.&#xD;&#xA;&#xD;&#xA;Default: 0"
                             min="0" max="100" increment="1"></slider-setting>
+            <bool-setting apply-on-change="true" text='Render In Front Of Environment' value='render-in-front-of-environment'
+                          hover-hint="Makes the screen render on top of the map environment instead of being blocked by it. Depends on the environment and may not work for every map.&#xD;&#xA;&#xD;&#xA;Recommended: Off"></bool-setting>
         </modifier-container>
     </tab>
 </vertical>


### PR DESCRIPTION
## Summary
- Adds a `RenderInFrontOfEnvironment` plugin setting (Visuals tab) that pushes the screen's render queue to `Overlay` and overrides `ZTest` to `Always`, so the video screen draws on top of the map environment instead of being occluded by it (#43).
- Applied to both the main screen and body materials whenever screen shader parameters are (re)applied, and on screen/body creation.
- Effect depends on the compiled screen shader exposing `_ZTest` as a property; if it doesn't, the setting is a no-op rather than erroring.