### PR TITLE
Fix Chroma screen duplication race for Lawless-mode maps

### DIFF
--- a/BeatSaberTheater/Environment/EnvironmentManipulator.cs
+++ b/BeatSaberTheater/Environment/EnvironmentManipulator.cs
@@ -343,11 +343,11 @@ public class EnvironmentManipulator : IInitializable
         _loggingService.Debug($"Screens found: {screenCount}");
         foreach (Transform screen in _playbackManager.gameObject.transform)
         {
-            if (!screen.name.StartsWith("CinemaScreen")) return;
+            if (!screen.name.StartsWith("CinemaScreen")) continue;
 
             var customBloomPrePass = screen.gameObject.GetComponent<CustomBloomPrePass>();
 
-            if (screen.name.Contains("(Clone)"))
+            if (screen.name.Contains("(Clone)") || screen.name.Contains("TheaterInternal"))
             {
                 _loggingService.Debug($"Cloning screen: {screen.name}");
                 if (!screen.name.Contains("TheaterInternal"))

--- a/BeatSaberTheater/Playback/PlaybackManager.cs
+++ b/BeatSaberTheater/Playback/PlaybackManager.cs
@@ -213,15 +213,6 @@ public class PlaybackManager : MonoBehaviour
 
     private void GameSceneActive()
     {
-        // If BSUtils has no level data, we're probably in the tutorial
-        if (BS_Utils.Plugin.LevelData.IsSet)
-        {
-            // Move to the environment scene to be picked up by Chroma
-            var sceneName = BS_Utils.Plugin.LevelData.GameplayCoreSceneSetupData.targetEnvironmentInfo.environmentSceneName;
-            var scene = SceneManager.GetSceneByName(sceneName);
-            SceneManager.MoveGameObjectToScene(gameObject, scene);
-        }
-
         _loggingService.Info("Moving to game scene");
     }
 
@@ -229,6 +220,18 @@ public class PlaybackManager : MonoBehaviour
     {
         StopAllCoroutines();
         _loggingService.Info("GameSceneLoaded");
+
+        // If BSUtils has no level data, we're probably in the tutorial
+        if (BS_Utils.Plugin.LevelData.IsSet)
+        {
+            // Move to the environment scene (only guaranteed loaded by this point) so Chroma's
+            // environment enhancement pass can find and duplicate our screen via "_id": "CinemaScreen$".
+            // Doing this earlier, in GameSceneActive, races the environment scene's async load.
+            var sceneName = TheaterFileHelpers.GetEnvironmentSceneName(
+                BS_Utils.Plugin.LevelData.GameplayCoreSceneSetupData.targetEnvironmentInfo);
+            var scene = SceneManager.GetSceneByName(sceneName);
+            SceneManager.MoveGameObjectToScene(gameObject, scene);
+        }
 
         _activeScene = Scene.SoloGameplay;
 

--- a/BeatSaberTheater/Util/TheaterFileHelpers.cs
+++ b/BeatSaberTheater/Util/TheaterFileHelpers.cs
@@ -134,4 +134,16 @@ public static class TheaterFileHelpers
     }
 
     public static string TheaterLibsPath => Path.Combine(UnityGame.LibraryPath, "Theater");
+
+    // Reflection-based so one build works against both BS 1.40.8 (sceneInfo.sceneName) and 1.44.1+ (environmentSceneName).
+    public static string GetEnvironmentSceneName(object environmentInfo)
+    {
+        var type = environmentInfo.GetType();
+
+        var sceneNameProperty = type.GetProperty("environmentSceneName");
+        if (sceneNameProperty != null) return (string)sceneNameProperty.GetValue(environmentInfo);
+
+        var sceneInfo = type.GetProperty("sceneInfo")!.GetValue(environmentInfo);
+        return (string)sceneInfo.GetType().GetProperty("sceneName")!.GetValue(sceneInfo);
+    }
 }

--- a/BeatSaberTheater/Video/VideoLoader.cs
+++ b/BeatSaberTheater/Video/VideoLoader.cs
@@ -353,7 +353,7 @@ internal class VideoLoader(
         if (videoConfig == null)
         {
             var mapPath = GetMapPath(level);
-            videoConfig = LoadConfig(GetConfigPath(mapPath));
+            if (mapPath != null) videoConfig = LoadConfig(GetConfigPath(mapPath));
         }
 
         if (InstalledMods.BeatSaberPlaylistsLib && videoConfig == null &&
@@ -362,9 +362,12 @@ internal class VideoLoader(
         return videoConfig ?? GetConfigFromBundledConfigs(level);
     }
 
-    private string GetMapPath(BeatmapLevel level)
+    private string? GetMapPath(BeatmapLevel level)
     {
-        _customLevelLoader._loadedBeatmapSaveData.TryGetValue(level.levelID, out var loadedSaveData);
+        // OST/base-game levels aren't custom levels and have no entry here
+        if (!_customLevelLoader._loadedBeatmapSaveData.TryGetValue(level.levelID, out var loadedSaveData))
+            return null;
+
         var mapPath = loadedSaveData.customLevelFolderInfo.folderPath;
         _loggingService.Debug($"Found map: {mapPath}");
 


### PR DESCRIPTION
## Summary
- Move Theater's screen-to-environment-scene placement from `PlaybackManager.GameSceneActive()` to `GameSceneLoaded()`, since `EnvironmentManipulator.SceneChanged`'s unconditional `DontDestroyOnLoad` call was undoing the placement before Chroma's environment-enhancement pass could find and duplicate the screen via `"_id": "CinemaScreen$"` (root cause of issue #41 on Chroma-duplicated Lawless-mode maps)
- Fix `PrepareClonedScreens` skipping the rest of the loop instead of just the current iteration when a child isn't a `CinemaScreen`
- Fix additional screens created via Theater's own multi-screen config (`additionalScreens`) never getting the video shader material assigned, since they don't have `"(Clone)"` in their name like Chroma-duplicated screens do — they rendered as solid pink instead of showing video
- Add a reflection-based scene name lookup (`TheaterFileHelpers.GetEnvironmentSceneName`) so one build works against both BS 1.40.8 and 1.44.1+